### PR TITLE
Unexpected Token

### DIFF
--- a/macos/notify.js
+++ b/macos/notify.js
@@ -26,7 +26,7 @@ var withTitle = app.systemAttribute('TITLE');
 var message = app.systemAttribute('MESSAGE');
 
 if (withTitle || message) {
-  app.displayNotification(message, {withTitle});
+  app.displayNotification(message, {withTitle: withTitle});
 } else {
   showNode();
 }


### PR DESCRIPTION
Compile was failing due to this object initializer, yet not on other instances of the same ES2015 syntax in my app. 
> SyntaxError: Unexpected token '}'. Expected a ':' following the property name 'withTitle'

```
/Users/xxx/node_modules/tag-shell/index.js:24
  if (proc.status) throw new Error(`${proc.stderr}`.trim());
                   ^

Error: /Users/xxx/node_modules/native-notifier/macos/notify.js:29: error: Error on line 29: SyntaxError: Unexpected token '}'. Expected a ':' following the property name 'withTitle'. (0)
  at sync (/Users/xxx/node_modules/tag-shell/index.js:24:26)
  at /Users/xxx/node_modules/tag-shell/index.js:18:10
  at getAppPath (/Users/xxx/node_modules/native-notifier/macos/index.js:14:7)
  at Object.module.exports.opts [as notify] (/Users/xxx/node_modules/native-notifier/macos/index.js:29:19)
  at Object._notify (/Users/xxx/node_modules/loggy/index.js:73:10)
  at Object.logger.(anonymous function) [as error] (/Users/xxx/
```