### PR TITLE
Handle wrapping errors from platform notifiers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,17 @@
 'use strict';
 const os = require('os').platform();
-const loadE = moduleName => require(moduleName).on('error', () => {});
 
-module.exports = (() => {
+const loadPlatformNotifier = () => {
   switch (os) {
-    case 'darwin': return loadE('./macos');
-    case 'linux': return loadE('./linux');
-    case 'win32': return loadE('./windows');
+    case 'darwin': return require('./macos');
+    case 'linux': return require('./linux');
+    case 'win32': return require('./windows');
+    default: return () => {};
   }
+}
 
-  return () => {};
-})();
+module.exports = (opts) => {
+  const platformNotifier = loadPlatformNotifier()
+
+  return platformNotifier(opts).on('error', () => {})
+}


### PR DESCRIPTION
`loadE` was expecting `require(moduleName)` to return a shell command, but the platform notifiers are themselves functions that return shell commands.

This properly wraps the platform notifiers so that errors are wrapped + handled. :)

This is an extension of:
- https://github.com/brunch/brunch/issues/1831
- https://github.com/paulmillr/native-notifier/issues/7