### PR TITLE
Silently ignore spawn errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 'use strict';
 const os = require('os').platform();
-const loadE = moduleName => require(moduleName).on('error', () => {});
+const loadE = moduleName => require(moduleName);
 
-module.exports = (() => {
+// Load the appropriate notify function based on the platform.
+const notifyFunc = (() => {
   switch (os) {
     case 'darwin': return loadE('./macos');
     case 'linux': return loadE('./linux');
@@ -11,3 +12,13 @@ module.exports = (() => {
 
   return () => {};
 })();
+
+// Export the notify function, but append a no-op error handler to silently
+// ignore failed child process spawns of the underlying OS notifier.  This
+// avoids uncaught exceptions that may occur if the expected OS notifier
+// doesn't exist, for example.
+module.exports = (opts) => {
+  const child = notifyFunc(opts);
+  child.on('error', () => {});
+  return child;
+};


### PR DESCRIPTION
Fixed the native notify function loading to append a no-op error handler to avoid process exits if the OS notifier doesn't exist.